### PR TITLE
'oSquishyList.change' events are dispatched on each call to 'squish'

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,30 +109,38 @@ function SquishyList(rootEl, opts) {
 		return hiddenItemEls;
 	}
 
-	function getRemainingItems() {
-		return allItemEls.filter(function(el) {
-			return hiddenItemEls.indexOf(el) === -1;
-		});
-	}
+    function getRemainingItems() {
+        return allItemEls.filter(function(el) {
+            return (hiddenItemEls && hiddenItemEls.indexOf(el) === -1);
+        });
+    }
 
-	function squish() {
-		showAllItems();
-		if (doesContentFit()) {
-			hideEl(moreEl);
-		} else {
-			for (var p = prioritySortedItemEls.length - 1; p >= 0; p--) {
-				hideItems(prioritySortedItemEls[p]);
-				if ((getVisibleContentWidth() + moreWidth) <= rootEl.clientWidth) {
-					showEl(moreEl);
-					break;
-				}
-			}
-		}
-		dispatchCustomEvent('oSquishyList.change', {
-			hiddenItems: getHiddenItems(),
-			remainingItems: getRemainingItems()
-		});
-	}
+    function squish() {
+        let previousHidden = getHiddenItems();
+        let previousRemaining = getRemainingItems();
+        showAllItems();
+        if (doesContentFit()) {
+            hideEl(moreEl);
+        } else {
+            for (let p = prioritySortedItemEls.length - 1; p >= 0; p--) {
+                hideItems(prioritySortedItemEls[p]);
+                if ((getVisibleContentWidth() + moreWidth) <= rootEl.clientWidth) {
+                    showEl(moreEl);
+                    break;
+                }
+            }
+        }
+        let hiddenItems = getHiddenItems();
+        let remainingItems = getRemainingItems();
+        let hiddenChanged = (previousHidden && previousHidden.length !== hiddenItems.length);
+        let remainingChanged = (previousRemaining && previousRemaining.length !== remainingItems.length);
+        if (!previousHidden || hiddenChanged || remainingChanged) {
+            dispatchCustomEvent('oSquishyList.change', {
+                hiddenItems: hiddenItems,
+                remainingItems: remainingItems
+            });
+        }
+    }
 
 	function resizeHandler() {
 		clearTimeout(debounceTimeout);

--- a/test/without-more.test.js
+++ b/test/without-more.test.js
@@ -186,4 +186,33 @@ describe("o-squishy-list behaviour without More", () => {
 
 	});
 
+    describe("Events not fired", () => {
+        let handlerSpy;
+
+        beforeEach(() => {
+            // reset so we can start from fresh to ensure that the first change event fires
+            testPCF.destroy();
+            fixtures.reset();
+
+            handlerSpy = jasmine.createSpy('handlerSpy')
+            document.body.addEventListener('oSquishyList.change', handlerSpy, false);
+
+            fixtures.insertWithoutMore();
+            pcfEl = document.querySelector('ul');
+            testPCF = new SquishyList(pcfEl);
+        });
+
+        afterEach(() => {
+            document.body.removeEventListener('oSquishyList.change', handlerSpy, false);
+        });
+
+        it("when squish is called without a change to the items", () => {
+            testPCF.squish();
+            expect(handlerSpy).toHaveBeenCalled();
+            handlerSpy.calls.reset();
+            testPCF.squish();
+            expect(handlerSpy).not.toHaveBeenCalled();
+        });
+    });
+
 });


### PR DESCRIPTION
Any call to 'squish' will trigger a 'oSquishyList.change' event even when there has been no change to the state of the list. This is causing an issue on o-hierarchical-nav that causes it to close incorrectly on mobile.

This fix is for v.1 but is also applicable to v.2