### PR TITLE
demo colours modified to pass pa11y test

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -33,16 +33,17 @@
 	}
 
 	[data-priority='2'] {
-		background-color: #999999;
+		background-color: #767676;
 	}
 
 	[data-priority='1'] {
 		background-color: #bbbbbb;
+		color: #4b4b4b;
 	}
 
 	[data-priority='-1'] {
 		background-color: #dddddd;
-		color: #888888;
+		color: #616161;
 	}
 
 	[data-more] {


### PR DESCRIPTION
I added the colours I mentioned [here](https://github.com/Financial-Times/o-squishy-list/pull/26)

Current demo:
![screen shot 2016-09-14 at 13 45 38](https://cloud.githubusercontent.com/assets/3081639/18512641/fb4924d0-7a81-11e6-9bcc-dcd73532f569.png)

New colours suggested by Pa11y:
![screen shot 2016-09-14 at 15 17 14](https://cloud.githubusercontent.com/assets/3081639/18515821/9d3fb2fc-7a8e-11e6-8c5e-c4d03b511177.png)

