### PR TITLE
Deprecate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # o-squishy-list [![Build Status](https://circleci.com/gh/Financial-Times/o-squishy-list.png?style=shield&circle-token=ee4f1c6916b8eccede740336aca671173da8f2b5)](https://circleci.com/gh/Financial-Times/o-squishy-list) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
+`o-squishy-list` has been deprecated. There are no direct alternatives; please [contact](#contact) the team if you would like to use this component.
+
 Hides lowest priority items when space does not allow.
 
 - [Usage](#usage)

--- a/origami.json
+++ b/origami.json
@@ -9,7 +9,7 @@
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
 	},
-	"supportStatus": "active",
+	"supportStatus": "deprecated",
 	"browserFeatures": {
 		"required": [
 			"createevent"


### PR DESCRIPTION
There are no known users, so we have decided to deprecate
`o-squishy-list`.