### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import SquishyList from './../../main'; // eslint-disable-line no-unused-vars
+import SquishyList from './../../main.js'; // eslint-disable-line no-unused-vars
 
 function initDemos() {
 	document.addEventListener("DOMContentLoaded", function() {

--- a/test/autoinitialization.test.js
+++ b/test/autoinitialization.test.js
@@ -1,6 +1,6 @@
 /* global proclaim, sinon */
-import * as fixtures from './helpers/fixtures';
-import SquishyList from './../main';
+import * as fixtures from './helpers/fixtures.js';
+import SquishyList from './../main.js';
 
 let pcfEl;
 

--- a/test/with-more.test.js
+++ b/test/with-more.test.js
@@ -1,6 +1,6 @@
 /* global proclaim */
-import * as fixtures from './helpers/fixtures';
-import SquishyList from './../main';
+import * as fixtures from './helpers/fixtures.js';
+import SquishyList from './../main.js';
 
 let testPCF;
 let pcfEl;

--- a/test/without-more.test.js
+++ b/test/without-more.test.js
@@ -1,6 +1,6 @@
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures.js.js';
+import * as fixtures from './helpers/fixtures.js';
 import SquishyList from './../main.js';
 
 let testPCF;

--- a/test/without-more.test.js
+++ b/test/without-more.test.js
@@ -1,7 +1,7 @@
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures.js';
-import SquishyList from './../main';
+import * as fixtures from './helpers/fixtures.js.js';
+import SquishyList from './../main.js';
 
 let testPCF;
 let pcfEl;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing